### PR TITLE
AP-128 Converted CURRENT_DATE() to CURRENT_TIMESTAMP()/CURRENT_DATETIME() in sql: parameters of various fields

### DIFF
--- a/date_base.view.lkml
+++ b/date_base.view.lkml
@@ -144,8 +144,14 @@ view: date_base {
   dimension: date_days_prior {
     hidden: yes
     type: number
-    sql: DATE_DIFF(${date_date}, CURRENT_DATE(), DAY) ;;
+    sql: DATE_DIFF(${date_date}, ${current_date_from_current_timestamp}, DAY) ;;
 #     expression: diff_days(${date_date}, now()) ;;
+  }
+
+  # Used in date_days_prior dimension.
+  dimension: current_date_from_current_timestamp {
+    type: date
+    sql: CURRENT_TIMESTAMP() ;;
   }
 
   dimension: date_day_of_7_days_prior {

--- a/period_base.view.lkml
+++ b/period_base.view.lkml
@@ -159,7 +159,7 @@ view: period_base {
     description: "Start date for last two periods"
     type: date
     group_label: "Event"
-    sql: TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -2
+    sql: TIMESTAMP(DATETIME_ADD(CURRENT_DATETIME(), INTERVAL -2
       {% if period._parameter_value contains "day" %}
         {% if period._parameter_value == "'7 day'" %}*7 DAY
         {% elsif period._parameter_value == "'28 day'" %}*28 DAY
@@ -175,11 +175,11 @@ view: period_base {
   }
 
   dimension: date_period_start_date_latest_period {
-    hidden: yes
+    hidden: no
     description: "Start date for last two periods"
     type: date
     group_label: "Event"
-    sql: TIMESTAMP(DATE_ADD(CURRENT_DATE(), INTERVAL -1
+    sql: TIMESTAMP(DATETIME_ADD(CURRENT_DATETIME(), INTERVAL -1
       {% if period._parameter_value contains "day" %}
         {% if period._parameter_value == "'7 day'" %}*7 DAY
         {% elsif period._parameter_value == "'28 day'" %}*28 DAY
@@ -199,7 +199,7 @@ view: period_base {
     description: "Start date for last two periods?"
     type: date
     group_label: "Event"
-    sql: TIMESTAMP(CURRENT_DATE());;
+    sql: CURRENT_TIMESTAMP() ;;
   }
 
   dimension: date_period_comparison_period {
@@ -314,7 +314,7 @@ view: period_fact_period_base {
       {% endif %} ;;
   }
   dimension: date_period_start_date_comparison_period {
-    sql: DATE_ADD(CURRENT_DATE(), INTERVAL -2
+    sql: DATETIME_ADD(CURRENT_DATETIME(), INTERVAL -2
       {% if period._parameter_value contains "day" %}
         {% if period._parameter_value == "'7 day'" %}*7 DAY
         {% elsif period._parameter_value == "'28 day'" %}*28 DAY


### PR DESCRIPTION
Summary: The GA360 App was having issues with date filtering (i.e. when selecting Period = "Day", we would get two days before the current date rather than the day before in our results). Similar issues happened when using different period values.

The root cause seemed to be the use of "CURRENT_DATE()" in various SQL parameters. The problem was that while our various date fields were converted based on the timezone selected in the front end, the SQL Looker generated when using "CURRENT_DATE()" in our fields would produce the current date (based on the database's timezone, which is UTC) and then convert that over to the selected timezone without having any time information (i.e. convert something like 01-01-2019 00:00:00).

Changing "CURRENT_DATE()" to "CURRENT_TIMESTAMP()"/"CURRENT_DATETIME()" seemed to have resolved the issue of timezone conversions.